### PR TITLE
Cherry-pick clipboard button per commit

### DIFF
--- a/src/main/resources/templates/BackportsResource/backports.html
+++ b/src/main/resources/templates/BackportsResource/backports.html
@@ -41,6 +41,11 @@
 											<i class="map marker alternate icon"></i>
 											<code class="ui tiny label"><a href="{commit.url}">{commit.abbreviatedOid}</a></code>
 											<a href="{commit.url}" target="_blank">{commit.abbreviatedMessage}</a>
+											{#if commits.size > 1}
+											<div class="ui tiny icon button right floated clipboard-button" data-clipboard-text="git cherry-pick -x {commit.oid}">
+												<i class="clipboard outline icon"></i>
+											</div>
+											{/if}
 										</div>
 									</div>
 									{/}


### PR DESCRIPTION
Cherry-pick clipboard button per commit

Useful when PR is not well formed and contains more commits than needed for backport.

Example:
<img width="1257" alt="Screenshot 2022-05-31 at 11 24 16" src="https://user-images.githubusercontent.com/925259/171140476-69604a56-211b-45f0-887d-03aa168c24d4.png">

