### PR TITLE
Detect possible follow-ups as PRs mentioned from the backport candidate

### DIFF
--- a/src/main/java/io/quarkus/backports/model/PossibleFollowupPullRequest.java
+++ b/src/main/java/io/quarkus/backports/model/PossibleFollowupPullRequest.java
@@ -1,0 +1,33 @@
+package io.quarkus.backports.model;
+
+import java.util.Objects;
+
+public class PossibleFollowupPullRequest {
+
+    public Integer id;
+
+    public String title;
+
+    public String url;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        PossibleFollowupPullRequest that = (PossibleFollowupPullRequest) o;
+        return Objects.equals(id, that.id) && Objects.equals(title, that.title) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, url);
+    }
+
+    @Override
+    public String toString() {
+        return "PossibleFollowupPullRequest{" +
+               "id=" + id +
+               ", title='" + title + '\'' +
+               ", url='" + url + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/io/quarkus/backports/model/PullRequest.java
+++ b/src/main/java/io/quarkus/backports/model/PullRequest.java
@@ -36,6 +36,8 @@ public class PullRequest implements Comparable<PullRequest> {
 
     public Set<String> labels;
 
+    public Set<PossibleFollowupPullRequest> possibleFollowupPullRequests;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/resources/META-INF/resources/css/main.css
+++ b/src/main/resources/META-INF/resources/css/main.css
@@ -45,6 +45,11 @@
 	margin-left: 4em;
 	margin-bottom: 0;
 }
+.ui.piled.segment.followups {
+	margin: 1em 0;
+	margin-left: 4em;
+	margin-bottom: 0;
+}
 .button.clipboard, .button.issues {
 	position: relative;
 }

--- a/src/main/resources/templates/BackportsResource/backports.html
+++ b/src/main/resources/templates/BackportsResource/backports.html
@@ -55,6 +55,18 @@
 									{/}
 								</div>
 							</div>
+							{#if pr.possibleFollowupPullRequests.size > 0}
+								<div class="ui piled segment followups">
+									<span>Possible follow-ups:</span><br/>
+									{#for followup in pr.possibleFollowupPullRequests}
+										<div class="commit">
+											<code class="ui tiny label"><a href="{followup.url}">{followup.id}</a></code>
+											<a href="{followup.url}" target="_blank">Pull request #{followup.id}</a>
+										</div>
+
+									{/}
+								</div>
+							{/}
 						</td>
 						<td class="center aligned">
 							<div class="ui icon button clipboard-button" data-clipboard-text="git cherry-pick -x {#for commit in commits}{commit.oid} {/}">

--- a/src/main/resources/templates/GitHubService/listPullRequests.graphql
+++ b/src/main/resources/templates/GitHubService/listPullRequests.graphql
@@ -40,8 +40,9 @@
         }
         # Issue events linked to this pull-request
         # See https://github.community/t/get-all-issues-linked-to-a-pull-request/14653/6
-        timelineItems(itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT], first: 100) {
+        timelineItems(itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT, ISSUE_COMMENT], first: 100) {
           nodes {
+            __typename
             ... on ConnectedEvent {
               subject {
                 ... on Issue {
@@ -67,6 +68,10 @@
                   number
                 }
               }
+            }
+            # To find other pull requests that were mentioned in this one
+            ... on IssueComment {
+              bodyHTML
             }
           }
         }


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus-backports/issues/232

Just a first draft to see if I should continue this effort or not. It currently looks at PRs referenced from the comments in the backport candidate PR, not the other way around yet. 

One imperfection is that it does not (yet) retrieve the titles of the possible follow-up PRs because that would require a separate GraphQL query for each of them, and this would potentially slow us down too much? I'm not sure, but I can try that. -- for now, it just prints the PR number in the UI.