### PR TITLE
Maintain project boards for backports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.23.0</quarkus.version>
+        <quarkus.version>3.24.3</quarkus.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <surefire-plugin.version>3.5.3</surefire-plugin.version>
-        <maven-artifact.version>3.9.9</maven-artifact.version>
+        <maven-artifact.version>3.9.10</maven-artifact.version>
         <assertj.version>3.27.3</assertj.version>
     </properties>
     <dependencyManagement>

--- a/src/main/java/io/quarkus/backports/BackportsResource.java
+++ b/src/main/java/io/quarkus/backports/BackportsResource.java
@@ -52,6 +52,8 @@ public class BackportsResource {
     @CacheInvalidateAll(cacheName = CacheNames.PULLREQUESTS_CACHE_NAME)
     @Blocking
     public TemplateInstance backports(@NotNull(message = "Invalid Milestone")  @RestPath final Milestone milestone) throws IOException {
+        gitHub.prepareRequirements(milestone);
+
         return Templates.backports(milestone, gitHub.getBackportCandidatesPullRequests());
     }
 

--- a/src/main/java/io/quarkus/backports/model/ProjectV2.java
+++ b/src/main/java/io/quarkus/backports/model/ProjectV2.java
@@ -1,0 +1,10 @@
+package io.quarkus.backports.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectV2 {
+    public String id;
+    public String title;
+    public Integer number;
+}

--- a/src/main/java/io/quarkus/backports/model/ProjectV2Field.java
+++ b/src/main/java/io/quarkus/backports/model/ProjectV2Field.java
@@ -1,0 +1,12 @@
+package io.quarkus.backports.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectV2Field {
+    public String id;
+    public String name;
+    public String dataType;
+    public List<ProjectV2FieldOption> options;
+}

--- a/src/main/java/io/quarkus/backports/model/ProjectV2FieldOption.java
+++ b/src/main/java/io/quarkus/backports/model/ProjectV2FieldOption.java
@@ -1,0 +1,11 @@
+package io.quarkus.backports.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectV2FieldOption {
+    public String id;
+    public String name;
+    public String color;
+    public String description;
+}

--- a/src/main/java/io/quarkus/backports/model/ProjectV2Item.java
+++ b/src/main/java/io/quarkus/backports/model/ProjectV2Item.java
@@ -1,0 +1,8 @@
+package io.quarkus.backports.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectV2Item {
+    public String id;
+}

--- a/src/main/java/io/quarkus/backports/model/Repository.java
+++ b/src/main/java/io/quarkus/backports/model/Repository.java
@@ -1,0 +1,13 @@
+package io.quarkus.backports.model;
+
+public record Repository(String fullName, String owner, String name) {
+
+    public static Repository fromString(String fullName) {
+        String[] parts = fullName.split("/");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid repository name: " + fullName);
+        }
+
+        return new Repository(fullName, parts[0], parts[1]);
+    }
+}

--- a/src/main/resources/templates/GitHubService/addItemToProjectV2.graphql
+++ b/src/main/resources/templates/GitHubService/addItemToProjectV2.graphql
@@ -1,0 +1,10 @@
+mutation AddItemToProject($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {
+    projectId: $projectId
+    contentId: $contentId
+  }) {
+    item {
+      id
+    }
+  }
+}

--- a/src/main/resources/templates/GitHubService/createProjectV2.graphql
+++ b/src/main/resources/templates/GitHubService/createProjectV2.graphql
@@ -1,0 +1,17 @@
+mutation CreateProjectV2(
+  $ownerId: ID!,
+  $repositoryId: ID!,
+  $title: String!
+) {
+  createProjectV2(input: {
+    ownerId: $ownerId
+    repositoryId: $repositoryId
+    title: $title
+  }) {
+    projectV2 {
+      id
+      title
+      number
+    }
+  }
+}

--- a/src/main/resources/templates/GitHubService/getOwnerInfo.graphql
+++ b/src/main/resources/templates/GitHubService/getOwnerInfo.graphql
@@ -1,0 +1,10 @@
+query GetOwnerInfo($owner: String!) {
+  organization(login: $owner) {
+    id
+    login
+  }
+  user(login: $owner) {
+    id
+    login
+  }
+}

--- a/src/main/resources/templates/GitHubService/getProjectV2FieldOptions.graphql
+++ b/src/main/resources/templates/GitHubService/getProjectV2FieldOptions.graphql
@@ -1,0 +1,20 @@
+query GetProjectV2FieldOptions($projectId: ID!, $fieldName: String!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      id
+      field(name: $fieldName) {
+        ... on ProjectV2SingleSelectField {
+          id
+          name
+          dataType
+          options {
+            id
+            name
+            color
+            description
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/GitHubService/getProjectsV2.graphql
+++ b/src/main/resources/templates/GitHubService/getProjectsV2.graphql
@@ -1,0 +1,11 @@
+query GetProjectsV2($owner: String!, $repository: String!) {
+  repository(owner: $owner, name: $repository) {
+    projectsV2(first: 100) {
+      nodes {
+        id
+        title
+        number
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/GitHubService/getRepositoryInfo.graphql
+++ b/src/main/resources/templates/GitHubService/getRepositoryInfo.graphql
@@ -1,0 +1,6 @@
+query GetRepositoryId($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    name
+  }
+}

--- a/src/main/resources/templates/GitHubService/updateProjectV2Field.graphql
+++ b/src/main/resources/templates/GitHubService/updateProjectV2Field.graphql
@@ -1,0 +1,26 @@
+mutation UpdateProjectV2Field(
+    $fieldId: ID!,
+    $name: String!,
+    $options: [ProjectV2SingleSelectFieldOptionInput!]!
+) {
+    updateProjectV2Field(
+        input: {
+            fieldId: $fieldId,
+            name: $name,
+            singleSelectOptions: $options
+        }
+    ) {
+        projectV2Field {
+            ... on ProjectV2SingleSelectField {
+                id
+                name
+                dataType
+                options {
+                    id
+                    name
+                    color
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/templates/GitHubService/updateProjectV2ItemFieldValue.graphql
+++ b/src/main/resources/templates/GitHubService/updateProjectV2ItemFieldValue.graphql
@@ -1,0 +1,19 @@
+mutation UpdateProjectV2ItemFieldValue(
+    $projectId: ID!,
+    $itemId: ID!,
+    $fieldId: ID!,
+    $optionId: String!
+) {
+    updateProjectV2ItemFieldValue(
+        input: {
+            projectId: $projectId,
+            itemId: $itemId,
+            fieldId: $fieldId,
+            value: { singleSelectOptionId: $optionId }
+        }
+    ) {
+        projectV2Item {
+            id
+        }
+    }
+}


### PR DESCRIPTION
It will allow us to keep track of the backported pull requests.

It is not perfect as it's unfortunately impossible to define the layout when creating a board so you have to switch to a BOARD layout manually in the UI.