### PR TITLE
Workaround limitations of the GitHub GraphQL API

### DIFF
--- a/src/main/java/io/quarkus/backports/BackportsResource.java
+++ b/src/main/java/io/quarkus/backports/BackportsResource.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.util.Collection;
 
 import io.quarkus.logging.Log;
+import io.quarkus.backports.model.ProjectV2;
+import io.quarkus.backports.model.ProjectV2Field;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.resteasy.reactive.RestPath;
 
@@ -22,6 +26,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateExtension;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.common.annotation.Blocking;
+import org.jboss.resteasy.reactive.RestQuery;
 
 @Path("/")
 public class BackportsResource {
@@ -37,6 +42,8 @@ public class BackportsResource {
         public static native TemplateInstance index(String repository, Collection<Milestone> milestones);
 
         public static native TemplateInstance backports(Milestone milestone, Collection<PullRequest> prs);
+
+        public static native TemplateInstance createStatusOptionForMilestone(ProjectV2 projectV2, Milestone milestone, String statusFieldSettingsUrl, String refreshStatusFieldUrl);
     }
 
     @GET
@@ -53,9 +60,28 @@ public class BackportsResource {
     @CacheInvalidateAll(cacheName = CacheNames.PULLREQUESTS_CACHE_NAME)
     @Blocking
     public TemplateInstance backports(@NotNull(message = "Invalid Milestone")  @RestPath final Milestone milestone) throws IOException {
-        gitHub.prepareRequirements(milestone);
+        ProjectV2 projectV2 = gitHub.prepareRequirements(milestone);
 
-        return Templates.backports(milestone, gitHub.getBackportCandidatesPullRequests());
+        if (gitHub.isMilestonePresentInStatusField(projectV2.id, milestone)) {
+            return Templates.backports(milestone, gitHub.getBackportCandidatesPullRequests());
+        } else {
+            return Templates.createStatusOptionForMilestone(projectV2, milestone, gitHub.getStatusFieldSettingsUrl(projectV2.number),
+                    UriBuilder.fromPath("/backports/{milestone}/refresh-status-field/{projectId}").resolveTemplate("milestone", milestone.title()).resolveTemplate("projectId", projectV2.id).build().toString());
+        }
+    }
+
+    @GET
+    @Path("/backports/{milestone}/refresh-status-field/{projectId}")
+    @Produces(MediaType.TEXT_HTML)
+    @Blocking
+    public Response backportsRefreshStatusField(@NotNull(message = "Invalid Milestone")  @RestPath final Milestone milestone,
+             @RestPath final String projectId) throws IOException {
+        ProjectV2Field statusField = gitHub.refreshStatusField(projectId);
+        if (!gitHub.isMilestonePresentInStatusField(projectId, milestone)) {
+            throw new IllegalStateException("Make sure you create the appropriate column in the project board and refresh");
+        }
+
+        return Response.temporaryRedirect(UriBuilder.fromPath("/backports/{milestone}/").resolveTemplate("milestone", milestone.title()).build()).build();
     }
 
     @GET
@@ -65,7 +91,7 @@ public class BackportsResource {
     public String markAsBackported(@NotNull(message = "Invalid Milestone") @RestPath Milestone milestone,
                                    @NotNull(message = "Invalid Pull Request") @RestPath PullRequest pullRequest) throws IOException {
         gitHub.markPullRequestAsBackported(pullRequest, milestone);
-        Log.info("Backported PR to " + milestone.title + ": " + pullRequest.url);
+        Log.info("Backported PR to " + milestone.title() + ": " + pullRequest.url);
         pullRequest.commits.forEach(commit -> {
             Log.info("    Backported commit: URL=" +  commit.url + ", message=" + commit.message);
         });

--- a/src/main/java/io/quarkus/backports/model/Milestone.java
+++ b/src/main/java/io/quarkus/backports/model/Milestone.java
@@ -7,30 +7,18 @@ import jakarta.enterprise.inject.spi.CDI;
 
 import io.quarkus.backports.GitHubService;
 
-public class Milestone {
-    public String id;
-
-    public String title;
+public record Milestone(String id, String title, String minorVersion) {
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Milestone)) return false;
-        Milestone milestone = (Milestone) o;
+        if (!(o instanceof Milestone milestone)) return false;
         return Objects.equals(title, milestone.title);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(title);
-    }
-
-    @Override
-    public String toString() {
-        return "Milestone{" +
-                "id='" + id + "', " +
-                "title='" + title + '\'' +
-                '}';
     }
 
     public static Milestone fromString(String title) throws IOException {

--- a/src/main/resources/templates/BackportsResource/createStatusOptionForMilestone.html
+++ b/src/main/resources/templates/BackportsResource/createStatusOptionForMilestone.html
@@ -1,0 +1,55 @@
+{#include BackportsResource/base}
+	{#page-class}milestone-choice{/page-class}
+	{#title}Backports{/title}
+	{#body}
+		<div class="ui main container">
+			<div class="ui one column centered grid">
+				<div class="column">
+					<div class="ui tall very padded piled segment">
+						<h3 class="ui header">Configure the project board</h3>
+						<div class="content">
+							<div class="ui warning icon message">
+								<i class="exclamation triangle icon"></i>
+								<div class="content">
+									<div class="header">
+										It is a shame but...
+									</div>
+									<p>The milestone you selected is not present in the project board for {milestone.minorVersion}.</p>
+									<p>Unfortunately, a GitHub GraphQL API limitation prevents us from creating new columns in the project board so you have to create the column manually.</p>
+								</div>
+							</div>
+							<p>&nbsp;</p>
+							<div class="ui two steps">
+								<div class="step">
+									<i class="tools icon"></i>
+									<div class="content">
+										<div class="title">Create {milestone.title} option</div>
+										<div class="description">Go to <a href="{statusFieldSettingsUrl}" target="_blank">Status settings page</a> and create the {milestone.title} option.</div>
+									</div>
+								</div>
+								<div class="step">
+									<i class="rocket icon"></i>
+									<div class="content">
+										<div class="title">You're done!</div>
+										<div class="description"><a href="{refreshStatusFieldUrl}">Go back to the backports page</a></div>
+									</div>
+								</div>
+							</div>
+							<p>&nbsp;</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	{/body}
+	{#scripts}
+		<script type="text/javascript">
+			$('select.dropdown').dropdown();
+
+			$('#lets-backport').click(function() {
+				window.location.href = '/backports/' + $('select#milestone').children("option:selected").val() + '/';
+				return false;
+			});
+		</script>
+	{/scripts}
+{/include}

--- a/test-gsmet.sh
+++ b/test-gsmet.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+export BACKPORTS_REPOSITORY="gsmet/test-backports"
+export BACKPORTS_LABEL="triage/backport"
+
+./mvnw clean quarkus:dev


### PR DESCRIPTION
For now, it is not possible to amend the list of options of the Status field (I opened an issue about it, but I wouldn't hold my breath).

So I created a new workflow that will:
- initialize a project with the usual suspects for backport
- bail out if it can't find this particular micro and ask for manual intervention (typically for emergency releases)